### PR TITLE
feat: node operator identity tracking

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ services:
    restart: always
    environment:
     - RedisConnection=redis:6379,password=StrongRedisPassword123!
+    # - AUTH_HTTP_MODE=api-key-env
+    # - HTTP_API_KEY=your-http-api-key-here
    ports:
     - 9002:8080
    build:
@@ -38,6 +40,8 @@ services:
    restart: always
    environment:
     - RedisConnection=redis:6379,password=StrongRedisPassword123!
+    # - AUTH_WS_MODE=api-key-env
+    # - WS_API_KEY=your-ws-api-key-here
    ports:
     - 9003:8080
    build:

--- a/src/Core/Domain/Contracts/Task/Models.cs
+++ b/src/Core/Domain/Contracts/Task/Models.cs
@@ -12,6 +12,7 @@ public sealed class TaskResponse
 {
     public string NodeId { get; set; }
     public TaskResponseData<object> Data { get; set; }
+    public long ReceivedAtMs { get; set; }
 }
 
 public sealed class TaskResponseData<T>

--- a/src/Core/Domain/Contracts/Task/TaskMetrics.cs
+++ b/src/Core/Domain/Contracts/Task/TaskMetrics.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Domain.Contracts;
+
+public sealed class TaskMetrics
+{
+    [JsonPropertyName("task_type")]
+    public string TaskType { get; set; } = string.Empty;
+
+    [JsonPropertyName("pipeline")]
+    public PipelineMetrics Pipeline { get; set; } = new();
+
+    [JsonPropertyName("nodes")]
+    public List<NodeContribution> Nodes { get; set; } = new();
+}
+
+public sealed class PipelineMetrics
+{
+    [JsonPropertyName("queue_wait_ms")]
+    public long QueueWaitMs { get; set; }
+
+    [JsonPropertyName("preprocessing_ms")]
+    public long PreprocessingMs { get; set; }
+
+    [JsonPropertyName("inference_ms")]
+    public long InferenceMs { get; set; }
+
+    [JsonPropertyName("postprocessing_ms")]
+    public long PostprocessingMs { get; set; }
+
+    [JsonPropertyName("total_ms")]
+    public long TotalMs { get; set; }
+}
+
+public sealed class NodeContribution
+{
+    [JsonPropertyName("node_id")]
+    public string NodeId { get; set; } = string.Empty;
+
+    [JsonPropertyName("inference_ms")]
+    public long InferenceMs { get; set; }
+}

--- a/src/Core/Domain/Contracts/Task/TaskMetrics.cs
+++ b/src/Core/Domain/Contracts/Task/TaskMetrics.cs
@@ -39,4 +39,7 @@ public sealed class NodeContribution
 
     [JsonPropertyName("inference_ms")]
     public long InferenceMs { get; set; }
+
+    [JsonPropertyName("operator_id")]
+    public string? OperatorId { get; set; }
 }

--- a/src/Core/Domain/Utilities/PrivateArgsHelper.cs
+++ b/src/Core/Domain/Utilities/PrivateArgsHelper.cs
@@ -19,4 +19,45 @@ public static class PrivateArgsHelper
             _ => defaultValue
         };
     }
+
+    public static long GetLong(Dictionary<string, object> args, string key, long defaultValue = 0)
+    {
+        if (!args.TryGetValue(key, out var value))
+            return defaultValue;
+
+        return value switch
+        {
+            long longValue => longValue,
+            int intValue => intValue,
+            JsonElement { ValueKind: JsonValueKind.Number } je => je.GetInt64(),
+            JsonElement { ValueKind: JsonValueKind.String } je
+                when long.TryParse(je.GetString(), out var parsed) => parsed,
+            not null when long.TryParse(value.ToString(), out var parsed) => parsed,
+            _ => defaultValue
+        };
+    }
+
+    public static void SetTimestamp(Dictionary<string, object> args, string key)
+    {
+        args[$"ts_{key}"] = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+    }
+
+    public static long GetTimestamp(Dictionary<string, object> args, string key)
+    {
+        return GetLong(args, $"ts_{key}");
+    }
+
+    public static string GetString(Dictionary<string, object> args, string key, string defaultValue = "")
+    {
+        if (!args.TryGetValue(key, out var value))
+            return defaultValue;
+
+        return value switch
+        {
+            string s => s,
+            JsonElement { ValueKind: JsonValueKind.String } je => je.GetString() ?? defaultValue,
+            not null => value.ToString() ?? defaultValue,
+            _ => defaultValue
+        };
+    }
 }

--- a/src/Core/Domain/Utilities/TaskMetricsBuilder.cs
+++ b/src/Core/Domain/Utilities/TaskMetricsBuilder.cs
@@ -1,0 +1,55 @@
+using Domain.Contracts;
+
+namespace Domain.Utilities;
+
+public static class TaskMetricsBuilder
+{
+    public static TaskMetrics Build(TaskRequest taskRequest, string nodeId)
+    {
+        var args = taskRequest.PrivateArgs;
+
+        var requestReceived = PrivateArgsHelper.GetTimestamp(args, "request_received");
+        var preprocessingStart = PrivateArgsHelper.GetTimestamp(args, "preprocessing_start");
+        var preprocessingEnd = PrivateArgsHelper.GetTimestamp(args, "preprocessing_end");
+        var distributeStart = PrivateArgsHelper.GetTimestamp(args, "distribute_start");
+        var nodeAcquired = PrivateArgsHelper.GetTimestamp(args, "node_acquired");
+        var sentToNode = PrivateArgsHelper.GetTimestamp(args, "sent_to_node");
+        var responseReceived = PrivateArgsHelper.GetLong(args, "ts_response_received");
+        var postprocessingStart = PrivateArgsHelper.GetTimestamp(args, "postprocessing_start");
+        var postprocessingEnd = PrivateArgsHelper.GetTimestamp(args, "postprocessing_end");
+
+        long SafeDiff(long end, long start) => end > 0 && start > 0 ? end - start : 0;
+
+        var queueWaitMs = SafeDiff(preprocessingStart, requestReceived)
+                        + SafeDiff(distributeStart, preprocessingEnd)
+                        + SafeDiff(nodeAcquired, distributeStart);
+
+        var preprocessingMs = SafeDiff(preprocessingEnd, preprocessingStart);
+        var inferenceMs = SafeDiff(responseReceived, sentToNode);
+        var postprocessingMs = SafeDiff(postprocessingEnd, postprocessingStart);
+        var totalMs = SafeDiff(postprocessingEnd, requestReceived);
+
+        var metrics = new TaskMetrics
+        {
+            TaskType = taskRequest.Task,
+            Pipeline = new PipelineMetrics
+            {
+                QueueWaitMs = queueWaitMs,
+                PreprocessingMs = preprocessingMs,
+                InferenceMs = inferenceMs,
+                PostprocessingMs = postprocessingMs,
+                TotalMs = totalMs,
+            },
+            Nodes = new List<NodeContribution>
+            {
+                new()
+                {
+                    NodeId = nodeId ?? PrivateArgsHelper.GetString(args, "node_id"),
+                    InferenceMs = inferenceMs,
+                }
+            }
+        };
+
+        return metrics;
+    }
+}

--- a/src/Core/Domain/Utilities/TaskMetricsBuilder.cs
+++ b/src/Core/Domain/Utilities/TaskMetricsBuilder.cs
@@ -15,6 +15,7 @@ public static class TaskMetricsBuilder
         var nodeAcquired = PrivateArgsHelper.GetTimestamp(args, "node_acquired");
         var sentToNode = PrivateArgsHelper.GetTimestamp(args, "sent_to_node");
         var responseReceived = PrivateArgsHelper.GetLong(args, "ts_response_received");
+        var operatorId = PrivateArgsHelper.GetString(args, "operator_id");
         var postprocessingStart = PrivateArgsHelper.GetTimestamp(args, "postprocessing_start");
         var postprocessingEnd = PrivateArgsHelper.GetTimestamp(args, "postprocessing_end");
 
@@ -46,6 +47,7 @@ public static class TaskMetricsBuilder
                 {
                     NodeId = nodeId ?? PrivateArgsHelper.GetString(args, "node_id"),
                     InferenceMs = inferenceMs,
+                    OperatorId = operatorId,
                 }
             }
         };

--- a/src/Core/Presentation/EndPoints/TasksEndPoints.cs
+++ b/src/Core/Presentation/EndPoints/TasksEndPoints.cs
@@ -7,11 +7,14 @@ using Domain.Contracts.Task.SpeechToText;
 using Domain.Contracts.Task.TextToSpeech;
 using Domain.Contracts.Task.Translation;
 using Domain.Contracts.Task.ImageTextToText;
+using Domain.Utilities;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
+using StackExchange.Redis;
 
 namespace Presentation.EndPoints;
 
@@ -159,6 +162,19 @@ public static class TasksEndPoints
         try
         {
             var request = await TaskRequestFactory.CreateFromForm(context.Request.Form, task);
+
+            if (request != null)
+            {
+                PrivateArgsHelper.SetTimestamp(request.PrivateArgs, "request_received");
+
+                var verbose = string.Equals(
+                    context.Request.Headers["X-Verbose"].FirstOrDefault(),
+                    "true",
+                    StringComparison.OrdinalIgnoreCase);
+                if (verbose)
+                    request.PrivateArgs["verbose"] = true;
+            }
+
             await ProcessTaskRequest(request, context, logic, cancellationToken);
         }
         catch (InvalidOperationException e)
@@ -275,6 +291,14 @@ public static class TasksEndPoints
 
                 context.Response.StatusCode = isError ? 500 : 200;
                 context.Response.ContentType = "application/json";
+
+                // If verbose requested, attach pipeline metrics
+                bool verbose = request.PrivateArgs.ContainsKey("verbose");
+                if (verbose && !isError)
+                {
+                    response = await AttachMetricsAsync(context, request, response);
+                }
+
                 await context.Response.WriteAsync(response, cancellationToken);
             }
             else
@@ -288,6 +312,43 @@ public static class TasksEndPoints
                     cancellationToken
                 );
             }
+        }
+    }
+
+    private static async Task<string> AttachMetricsAsync(
+        HttpContext context,
+        TaskRequest request,
+        string response)
+    {
+        try
+        {
+            var redis = context.RequestServices.GetRequiredService<IConnectionMultiplexer>();
+            var db = redis.GetDatabase();
+            var metricsJson = await db.StringGetAsync($"metrics:{request.Id}");
+
+            if (!metricsJson.HasValue)
+                return response;
+
+            var metrics = JsonSerializer.Deserialize<TaskMetrics>(metricsJson.ToString());
+            if (metrics == null)
+                return response;
+
+            // Clean up the metrics key
+            await db.KeyDeleteAsync($"metrics:{request.Id}");
+
+            // Parse original response and wrap with metrics
+            using var doc = JsonDocument.Parse(response);
+            var wrapped = new Dictionary<string, object>
+            {
+                ["result"] = doc.RootElement,
+                ["metrics"] = metrics
+            };
+
+            return JsonSerializer.Serialize(wrapped);
+        }
+        catch
+        {
+            return response;
         }
     }
 }

--- a/src/Core/Presentation/Queues/DistributeQueue.cs
+++ b/src/Core/Presentation/Queues/DistributeQueue.cs
@@ -1,6 +1,7 @@
 using System.Net.WebSockets;
 using System.Text;
 using System.Text.Json;
+using Domain.Utilities;
 using Infrastructure.Redis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -57,6 +58,8 @@ public sealed class DistributeQueue : BackgroundService
             var taskRequest = JsonSerializer.Deserialize<TaskRequest>(message);
             if (taskRequest != null)
             {
+                PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "distribute_start");
+
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
                 timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
 
@@ -76,11 +79,14 @@ public sealed class DistributeQueue : BackgroundService
                     throw new Exception("No available nodes");
                 }
 
+                PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "node_acquired");
                 taskRequest.PrivateArgs["node_id"] = id.ToString();
 
                 var db = _redis.GetDatabase();
 
-                await db.StringSetAsync($"task:{taskRequest.Id}", message, TimeSpan.FromMinutes(10));
+                // Store the task with updated timestamps in Redis
+                var taskJson = JsonSerializer.Serialize(taskRequest);
+                await db.StringSetAsync($"task:{taskRequest.Id}", taskJson, TimeSpan.FromMinutes(10));
 
                 await taskRequest.LoadInputIfNeeded();
 
@@ -101,6 +107,13 @@ public sealed class DistributeQueue : BackgroundService
                     true,
                     stoppingToken
                 );
+
+                PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "sent_to_node");
+                // Update Redis with the sent_to_node timestamp
+                await db.StringSetAsync(
+                    $"task:{taskRequest.Id}",
+                    JsonSerializer.Serialize(taskRequest),
+                    TimeSpan.FromMinutes(10));
 
                 await _publisher.PublishAsync(StreamNames.SessionTracking, taskRequest.Id.ToString());
             }

--- a/src/Core/Presentation/Queues/DistributeQueue.cs
+++ b/src/Core/Presentation/Queues/DistributeQueue.cs
@@ -63,11 +63,12 @@ public sealed class DistributeQueue : BackgroundService
                 using var timeoutCts = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
                 timeoutCts.CancelAfter(TimeSpan.FromSeconds(30));
 
-                string id;
-                System.Net.WebSockets.WebSocket webSocket;
+                string? id;
+                System.Net.WebSockets.WebSocket? webSocket;
+                string? operatorId;
                 try
                 {
-                    (id, webSocket) = await _webSocketNodesQueue.GetAvailableWebsocketAsync(timeoutCts.Token);
+                    (id, webSocket, operatorId) = await _webSocketNodesQueue.GetAvailableWebsocketAsync(timeoutCts.Token);
                 }
                 catch (OperationCanceledException) when (!stoppingToken.IsCancellationRequested)
                 {
@@ -81,6 +82,10 @@ public sealed class DistributeQueue : BackgroundService
 
                 PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "node_acquired");
                 taskRequest.PrivateArgs["node_id"] = id.ToString();
+                if (operatorId != null)
+                {
+                    taskRequest.PrivateArgs["operator_id"] = operatorId;
+                }
 
                 var db = _redis.GetDatabase();
 

--- a/src/Core/Presentation/Queues/PostProcessingQueue.cs
+++ b/src/Core/Presentation/Queues/PostProcessingQueue.cs
@@ -101,11 +101,11 @@ public sealed class PostProcessingQueue(
 
             try
             {
-                await ProcessTaskResponseAsync(taskResponse, taskRequest);
-
+                // Store metrics BEFORE publishing result to avoid race condition:
+                // the HTTP handler reads metrics from Redis immediately after receiving
+                // the result from result_queue, so metrics must be written first.
                 PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "postprocessing_end");
 
-                // Store metrics in Redis if verbose was requested
                 if (taskRequest.PrivateArgs.ContainsKey("verbose"))
                 {
                     var metricsKey = taskRequest.PrivateArgs.ContainsKey("parent")
@@ -118,6 +118,8 @@ public sealed class PostProcessingQueue(
                         JsonSerializer.Serialize(metrics),
                         TimeSpan.FromMinutes(5));
                 }
+
+                await ProcessTaskResponseAsync(taskResponse, taskRequest);
 
                 var completionId = taskRequest.Id;
                 var completionData = JsonSerializer.Serialize(

--- a/src/Core/Presentation/Queues/PostProcessingQueue.cs
+++ b/src/Core/Presentation/Queues/PostProcessingQueue.cs
@@ -91,9 +91,33 @@ public sealed class PostProcessingQueue(
             }
             taskId = taskRequest.Id.ToString();
 
+            // Copy the response-received timestamp from the WS service
+            if (taskResponse.ReceivedAtMs > 0)
+            {
+                taskRequest.PrivateArgs["ts_response_received"] = taskResponse.ReceivedAtMs;
+            }
+
+            PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "postprocessing_start");
+
             try
             {
                 await ProcessTaskResponseAsync(taskResponse, taskRequest);
+
+                PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "postprocessing_end");
+
+                // Store metrics in Redis if verbose was requested
+                if (taskRequest.PrivateArgs.ContainsKey("verbose"))
+                {
+                    var metricsKey = taskRequest.PrivateArgs.ContainsKey("parent")
+                        ? $"metrics:{PrivateArgsHelper.GetString(taskRequest.PrivateArgs, "parent")}"
+                        : $"metrics:{taskRequest.Id}";
+
+                    var metrics = TaskMetricsBuilder.Build(taskRequest, taskResponse.NodeId);
+                    await db.StringSetAsync(
+                        metricsKey,
+                        JsonSerializer.Serialize(metrics),
+                        TimeSpan.FromMinutes(5));
+                }
 
                 var completionId = taskRequest.Id;
                 var completionData = JsonSerializer.Serialize(

--- a/src/Core/Presentation/Queues/PreProcessingQueue.cs
+++ b/src/Core/Presentation/Queues/PreProcessingQueue.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using Application.Logic;
 using Contracts.Constants;
+using Domain.Utilities;
 using Infrastructure.Redis;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -45,11 +46,14 @@ public sealed class PreProcessingQueue(
             if (taskRequest == null)
                 return;
 
+            PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "preprocessing_start");
+
             // Route tasks based on their type
             switch (taskRequest.Task)
             {
                 case var task when task == AvailableModels.SpeechToText:
                     // Audio files need to be split by silence
+                    PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "preprocessing_end");
                     await logic.PublishSplitAudioBySilenceQueueAsync(taskRequest);
                     break;
 
@@ -58,6 +62,7 @@ public sealed class PreProcessingQueue(
                     if (EnsureValidTextToSpeechInput(taskRequest))
                     {
                         // Text needs to be split for TTS processing
+                        PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "preprocessing_end");
                         await logic.PublishSplitTextQueueAsync(taskRequest);
                     }
                     else
@@ -77,6 +82,7 @@ public sealed class PreProcessingQueue(
                         || task == AvailableModels.TextGeneration
                         || task == AvailableModels.ImageTextToText:
                     // These tasks don't need preprocessing, send directly to distribution
+                    PrivateArgsHelper.SetTimestamp(taskRequest.PrivateArgs, "preprocessing_end");
                     await logic.PublishDistributeQueueAsync(taskRequest);
                     break;
 

--- a/src/Core/Presentation/WebSockets/TaskSockets.cs
+++ b/src/Core/Presentation/WebSockets/TaskSockets.cs
@@ -144,6 +144,7 @@ public static class TaskSockets
                         {
                             NodeId = id,
                             Data = responseBody?.Data ?? new TaskResponseData<object>(),
+                            ReceivedAtMs = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds(),
                         };
 
                         await streamPublisher.PublishAsync(

--- a/src/Core/Presentation/WebSockets/TaskSockets.cs
+++ b/src/Core/Presentation/WebSockets/TaskSockets.cs
@@ -17,6 +17,26 @@ public static class TaskSockets
 {
     private const int MaxMessageSize = 10 * 1024 * 1024; // 10 MB per message
 
+    private static readonly bool WsAuthEnabled;
+    private static readonly string? WsApiKey;
+
+    static TaskSockets()
+    {
+        var mode = Environment.GetEnvironmentVariable("AUTH_WS_MODE") ?? "none";
+        WsAuthEnabled = string.Equals(mode, "api-key-env", StringComparison.OrdinalIgnoreCase);
+
+        if (WsAuthEnabled)
+        {
+            WsApiKey = Environment.GetEnvironmentVariable("WS_API_KEY");
+            if (string.IsNullOrEmpty(WsApiKey))
+            {
+                Console.WriteLine(
+                    "[Auth] WARNING: AUTH_WS_MODE=api-key-env but WS_API_KEY is not set. " +
+                    "All WebSocket connections will be rejected with 4001.");
+            }
+        }
+    }
+
     public static void AddTaskSockets(this IEndpointRouteBuilder app)
     {
         var group = app.MapGroup("ws/");
@@ -43,6 +63,21 @@ public static class TaskSockets
                 JsonSerializer.Serialize(new { error = "Invalid ID." })
             );
             return;
+        }
+
+        // Validate token BEFORE accepting the WebSocket connection
+        if (WsAuthEnabled)
+        {
+            var token = context.Request.Query["token"].FirstOrDefault();
+            if (string.IsNullOrEmpty(token) ||
+                string.IsNullOrEmpty(WsApiKey) ||
+                !string.Equals(token, WsApiKey, StringComparison.Ordinal))
+            {
+                context.Response.StatusCode = 401;
+                await context.Response.WriteAsync(
+                    JsonSerializer.Serialize(new { error = "Unauthorized" }));
+                return;
+            }
         }
 
         var webSocket = await context.WebSockets.AcceptWebSocketAsync();

--- a/src/Core/Presentation/WebSockets/TaskSockets.cs
+++ b/src/Core/Presentation/WebSockets/TaskSockets.cs
@@ -80,9 +80,11 @@ public static class TaskSockets
             }
         }
 
+        var operatorId = context.Request.Query["operator"].FirstOrDefault();
+
         var webSocket = await context.WebSockets.AcceptWebSocketAsync();
 
-        await webSocketNodesQueue.AddWebsocketInQueueAsync(id, webSocket);
+        await webSocketNodesQueue.AddWebsocketInQueueAsync(id, webSocket, operatorId);
         var connectionId = await webSocketNodesQueue.AddConnectionAsync(id, webSocket);
 
         var buffer = new byte[1024 * 4];
@@ -160,7 +162,7 @@ public static class TaskSockets
                     }
                 }
 
-                await webSocketNodesQueue.AddWebsocketInQueueAsync(id, webSocket);
+                await webSocketNodesQueue.AddWebsocketInQueueAsync(id, webSocket, operatorId);
             } while (!result.CloseStatus.HasValue);
 
             await webSocket.CloseAsync(

--- a/src/Core/Presentation/WebSockets/WebSocketNodesQueue.cs
+++ b/src/Core/Presentation/WebSockets/WebSocketNodesQueue.cs
@@ -10,7 +10,7 @@ namespace Presentation.Websockets;
 
 public class WebSocketNodesQueue
 {
-    private readonly Channel<(string, WebSocket)> _queue = Channel.CreateBounded<(string, WebSocket)>(
+    private readonly Channel<(string, WebSocket, string?)> _queue = Channel.CreateBounded<(string, WebSocket, string?)>(
         new BoundedChannelOptions(1000)
         {
             FullMode = BoundedChannelFullMode.Wait,
@@ -22,12 +22,12 @@ public class WebSocketNodesQueue
     private int _connectionCount = 0;
     private readonly SemaphoreSlim _broadcastSemaphore = new(1, 1);
 
-    public async Task AddWebsocketInQueueAsync(string nodeId, WebSocket socket)
+    public async Task AddWebsocketInQueueAsync(string nodeId, WebSocket socket, string? operatorId = null)
     {
-        await _queue.Writer.WriteAsync((nodeId, socket));
+        await _queue.Writer.WriteAsync((nodeId, socket, operatorId));
     }
 
-    public async Task<(string?, WebSocket?)> GetAvailableWebsocketAsync(CancellationToken ct = default)
+    public async Task<(string?, WebSocket?, string?)> GetAvailableWebsocketAsync(CancellationToken ct = default)
     {
         while (await _queue.Reader.WaitToReadAsync(ct))
         {
@@ -40,7 +40,7 @@ public class WebSocketNodesQueue
             }
         }
 
-        return (null, null);
+        return (null, null, null);
     }
 
     public async Task<string> AddConnectionAsync(string nodeId, WebSocket socket)

--- a/src/WebApi/Middleware/ApiKeyAuthMiddleware.cs
+++ b/src/WebApi/Middleware/ApiKeyAuthMiddleware.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+
+namespace WebApi.Middleware;
+
+/// <summary>
+/// Middleware that validates an API key on HTTP requests to /api/ routes.
+/// Controlled by the AUTH_HTTP_MODE environment variable:
+///   - "none" (default): all requests pass through without auth
+///   - "api-key-env": validates the X-API-Key header against HTTP_API_KEY env var
+/// </summary>
+public sealed class ApiKeyAuthMiddleware
+{
+    private readonly RequestDelegate _next;
+    private readonly bool _enabled;
+    private readonly string? _expectedKey;
+
+    public ApiKeyAuthMiddleware(RequestDelegate next)
+    {
+        _next = next;
+
+        var mode = Environment.GetEnvironmentVariable("AUTH_HTTP_MODE") ?? "none";
+        _enabled = string.Equals(mode, "api-key-env", StringComparison.OrdinalIgnoreCase);
+
+        if (_enabled)
+        {
+            _expectedKey = Environment.GetEnvironmentVariable("HTTP_API_KEY");
+            if (string.IsNullOrEmpty(_expectedKey))
+            {
+                Console.WriteLine(
+                    "[Auth] WARNING: AUTH_HTTP_MODE=api-key-env but HTTP_API_KEY is not set. " +
+                    "All /api/ requests will be rejected with 401.");
+            }
+        }
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        if (!_enabled)
+        {
+            await _next(context);
+            return;
+        }
+
+        // Only protect /api/ routes
+        var path = context.Request.Path.Value ?? string.Empty;
+        if (!path.StartsWith("/api/", StringComparison.OrdinalIgnoreCase))
+        {
+            await _next(context);
+            return;
+        }
+
+        var providedKey = context.Request.Headers["X-API-Key"].FirstOrDefault();
+
+        if (string.IsNullOrEmpty(providedKey) ||
+            string.IsNullOrEmpty(_expectedKey) ||
+            !string.Equals(providedKey, _expectedKey, StringComparison.Ordinal))
+        {
+            context.Response.StatusCode = 401;
+            context.Response.ContentType = "application/json";
+            await context.Response.WriteAsync(
+                JsonSerializer.Serialize(new { error = "Unauthorized" }));
+            return;
+        }
+
+        await _next(context);
+    }
+}
+
+public static class ApiKeyAuthMiddlewareExtensions
+{
+    public static IApplicationBuilder UseApiKeyAuth(this IApplicationBuilder app)
+    {
+        return app.UseMiddleware<ApiKeyAuthMiddleware>();
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using Presentation;
 using WebApi;
 using WebApi.Filters;
+using WebApi.Middleware;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -111,6 +112,8 @@ builder.Services
 var app = builder.Build();
 
 app.UseCors("CorsPolicy");
+
+app.UseApiKeyAuth();
 
 app.UseRateLimiter();
 


### PR DESCRIPTION
## Summary
- Track node operator identity through the entire task pipeline from WebSocket connection to metrics
- Pass `operator={userId}` in upstream WS URI so server can attribute inference work to node operators
- Fix race condition in PostProcessingQueue: store metrics in Redis BEFORE publishing result to result_queue
- Add `OperatorId` to `NodeContribution` in TaskMetrics

## Files changed
- `TaskSockets.cs` — read `operator` query param from WS connection
- `WebSocketNodesQueue.cs` — store operator_id alongside nodeId in channel
- `DistributeQueue.cs` — store operator_id in taskRequest.PrivateArgs
- `TaskMetrics.cs` — add OperatorId to NodeContribution
- `TaskMetricsBuilder.cs` — include operator_id in built metrics
- `PostProcessingQueue.cs` — fix race condition (metrics before result)

## Test plan
- [x] Node connects via gateway WS with operator param
- [x] operator_id flows through pipeline: WS → Redis → metrics → HTTP response
- [x] operator_id appears in PostgreSQL inference_node_contributions
- [x] Race condition fix verified: metrics available when core-api reads them

🤖 Generated with [Claude Code](https://claude.com/claude-code)